### PR TITLE
Added Type to conversation sensor to enable custom inbox card

### DIFF
--- a/homeassistant/components/instructure/sensor.py
+++ b/homeassistant/components/instructure/sensor.py
@@ -95,6 +95,7 @@ SENSOR_DESCRIPTIONS: {str: CanvasSensorEntityDescription} = {
         if data
         else "",
         attr_fn=lambda data, courses: {
+            "Type": "conversation",
             "Course": data["context_name"],
             "Initial Sender": data["participants"][0]["name"],
             "Last Message": data["last_message"],


### PR DESCRIPTION
In the custom inbox card we filter entities to find conversations, this must be added to separate conversations from other entities